### PR TITLE
[smtr][transporte_rodoviario_municipal] dates hotfix

### DIFF
--- a/models/transporte_rodoviario_municipal/viagem_onibus.sql
+++ b/models/transporte_rodoviario_municipal/viagem_onibus.sql
@@ -29,13 +29,4 @@ SELECT
     perc_conformidade_registros,
     versao_modelo
 FROM rj-smtr.projeto_subsidio_sppo.viagem_completa 
-WHERE data < DATE_SUB(DATE("{{ var("run_date") }}"), INTERVAL 1 DAY)
-
-{% if is_incremental() %}
-
-{% set max_partition = run_query("SELECT gr FROM (SELECT IF(MAX(data) > DATE_SUB(DATE('" ~ var("run_date") ~ "'), INTERVAL 1 DAY), DATE_SUB(DATE('" ~ var("run_date") ~ "'), INTERVAL 1 DAY), MAX(data)) AS gr FROM " ~ this ~ ")").columns[0].values()[0] %}
-
-AND
-    data > DATE("{{ max_partition }}")
-
-{% endif %}
+WHERE data BETWEEN "2022-06-01" AND DATE_SUB(DATE("{{ var("run_date") }}"), INTERVAL 1 DAY)


### PR DESCRIPTION
Altera o model `viagem_onibus`, atualizando todas as viagens conforme `rj-smtr.projeto_subsidio_sppo.viagem_completa`. A tabela já se encontra configurada com `incremental_strategy='insert_overwrite'`. Dessa forma, as alterações na `viagem_completa`  serão refletidas na tabela em referência sem duplicações.

Da forma que se encontrava, atualizações em dias anteriores da `viagem_completa` não são refletidos na tabela em questão, haja vista a query realizar o `SELECT` apenas a partir da última data da que já se encontrava na tabela.