### PR TITLE
[hotfix] clima_estacao_meteorologica

### DIFF
--- a/models/clima_estacao_meteorologica/clima_estacao_meteorologica_estacoes_inmet.sql
+++ b/models/clima_estacao_meteorologica/clima_estacao_meteorologica_estacoes_inmet.sql
@@ -1,1 +1,7 @@
+{{ 
+config(
+    alias='estacoes_inmet'
+)
+}}
+
 SELECT * FROM `rj-cor.clima_estacao_meteorologica.estacoes_inmet`

--- a/models/clima_estacao_meteorologica/clima_estacao_meteorologica_meteorologia_inmet.sql
+++ b/models/clima_estacao_meteorologica/clima_estacao_meteorologica_meteorologia_inmet.sql
@@ -1,5 +1,6 @@
 {{
     config(
+        alias='meteorologia_inmet',
         materialized='incremental',
         unique_key="primary_key",
         partition_by={

--- a/models/clima_estacao_meteorologica/schema.yml
+++ b/models/clima_estacao_meteorologica/schema.yml
@@ -1,6 +1,6 @@
 version: 2
 models :
-  - name: meteorologia_inmet
+  - name: clima_estacao_meteorologica_meteorologia_inmet
     description: "**Descrição**: Dados meteorológicos obtidos nas estações pluviométricas\
       \ do INMET ( Instituto Nacional de Meteorologia ) na cidade do Rio de Janeiro.\r\
       \nAs medidas são feitas de hora em hora, cada registro contendo dados destas\
@@ -54,7 +54,7 @@ models :
         description: Chave primária criada a partir da concatenação da coluna id_estacao,
           data e horário Serve para evitar dados duplicados.
 
-  - name: estacoes_inmet
+  - name: clima_estacao_meteorologica_estacoes_inmet
     description: "**Descrição**: Dados sobre as estações meteorológicas do inmet (\
       \ Instituto Nacional de Meteorologia ) na cidade do Rio de Janeiro.\n**Frequência\
       \ de atualização**: Nunca\n**Cobertura temporal**: N/A\n**Órgão gestor dos dados**:\


### PR DESCRIPTION
Altera o nome das tabelas no model `clima_estacao_meteorologica` para não haver conflito com o model `meio_ambiente_clima`, mas mantém os alias.